### PR TITLE
Gemfileにpryのbyebug rails追加 docker-compose.yml database.ymlに追加　アプリ起動するが動かず

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "pry-rails"
+  gem "pry-byebug" 
 end
 
 group :development do


### PR DESCRIPTION
group :development, :test do

 gem "pry-rails"
  gem "pry-byebug" 
end


■docker-compose.yml
version: "3.2"

services:
  database:
    restart: always
    image: mysql:latest
    ports:
      - 3306:3306
    command: --default-authentication-plugin=mysql_native_password
    volumes:
      - mysql-datavolume:/var/lib/mysql
    environment:
      MYSQL_ROOT_PASSWORD: root
jnjnnnmmmnn
volumes:
  mysql-datavolume:
    driver: local

■database.yml

default: &default
  adapter: mysql2
  encoding: utf8
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  username: root
  password: root
  host: 127.0.0.1

development:
  <<: *default
  database: line_todo_list_development

test:
  <<: *default
  database: line_todo_list_test

production:
  <<: *default
  database: line_todo_list_production
  username: line_todo_list
  password: <%= ENV['LINE_TODO_LIST_DATABASE_PASSWORD'] %>